### PR TITLE
Add cpp extension patch

### DIFF
--- a/recipe/05-cpp-extension.patch
+++ b/recipe/05-cpp-extension.patch
@@ -1,0 +1,91 @@
+diff --git a/torch/utils/cpp_extension.py b/torch/utils/cpp_extension.py
+index 1178fcd993..5a3f4c7e31 100644
+--- a/torch/utils/cpp_extension.py
++++ b/torch/utils/cpp_extension.py
+@@ -357,18 +357,24 @@ class BuildExtension(build_ext, object):
+         else:
+             original_compile = self.compiler._compile
+ 
+-        def append_std14_if_no_std_present(cflags):
++        def append_std14_if_no_std_present(cflags, with_cuda):
+             # NVCC does not allow multiple -std to be passed, so we avoid
+             # overriding the option if the user explicitly passed it.
++            if with_cuda:
++                std_val = 'c++14'
++            else:
++                std_val = 'gnu++14'
++
+             cpp_format_prefix = '/{}:' if self.compiler.compiler_type == 'msvc' else '-{}='
+             cpp_flag_prefix = cpp_format_prefix.format('std')
+-            cpp_flag = cpp_flag_prefix + 'c++14'
++            cpp_flag = cpp_flag_prefix + std_val
+             if not any(flag.startswith(cpp_flag_prefix) for flag in cflags):
+                 cflags.append(cpp_flag)
+ 
+         def unix_cuda_flags(cflags):
+             return (COMMON_NVCC_FLAGS +
+                     ['--compiler-options', "'-fPIC'"] +
++                    (['-ccbin', os.environ['CC']] if 'CC' in os.environ else []) +
+                     cflags + _get_cuda_arch_flags(cflags))
+ 
+         def convert_to_absolute_paths_inplace(paths):
+@@ -394,11 +400,13 @@ class BuildExtension(build_ext, object):
+                         cflags = cflags + _get_rocm_arch_flags(cflags)
+                     else:
+                         cflags = unix_cuda_flags(cflags)
++                    append_std14_if_no_std_present(cflags, True)
+                 elif isinstance(cflags, dict):
+                     cflags = cflags['cxx']
++                    append_std14_if_no_std_present(cflags, False)
+                 if IS_HIP_EXTENSION:
+                     cflags = cflags + COMMON_HIPCC_FLAGS
+-                append_std14_if_no_std_present(cflags)
++                    append_std14_if_no_std_present(cflags, False)
+ 
+                 original_compile(obj, src, ext, cc_args, cflags, pp_opts)
+             finally:
+@@ -447,7 +455,7 @@ class BuildExtension(build_ext, object):
+                 post_cflags = list(extra_postargs)
+             if IS_HIP_EXTENSION:
+                 post_cflags += COMMON_HIPCC_FLAGS
+-            append_std14_if_no_std_present(post_cflags)
++            append_std14_if_no_std_present(post_cflags, with_cuda)
+ 
+             cuda_post_cflags = None
+             cuda_cflags = None
+@@ -462,7 +470,7 @@ class BuildExtension(build_ext, object):
+                     cuda_post_cflags = cuda_post_cflags + COMMON_HIPCC_FLAGS
+                 else:
+                     cuda_post_cflags = unix_cuda_flags(cuda_post_cflags)
+-                append_std14_if_no_std_present(cuda_post_cflags)
++                append_std14_if_no_std_present(cuda_post_cflags, with_cuda)
+                 cuda_cflags = [shlex.quote(f) for f in cuda_cflags]
+                 cuda_post_cflags = [shlex.quote(f) for f in cuda_post_cflags]
+ 
+@@ -523,6 +531,8 @@ class BuildExtension(build_ext, object):
+                         nvcc = _join_cuda_home('bin', 'nvcc')
+                         if isinstance(self.cflags, dict):
+                             cflags = self.cflags['nvcc']
++                            if 'CC' in os.environ:
++                                cflags += ['-ccbin', os.environ['CC']]
+                         elif isinstance(self.cflags, list):
+                             cflags = self.cflags
+                         else:
+@@ -593,7 +603,7 @@ class BuildExtension(build_ext, object):
+                 post_cflags = extra_postargs['cxx']
+             else:
+                 post_cflags = list(extra_postargs)
+-            append_std14_if_no_std_present(post_cflags)
++            append_std14_if_no_std_present(post_cflags, with_cuda)
+ 
+             cuda_post_cflags = None
+             cuda_cflags = None
+@@ -1599,6 +1609,8 @@ def _write_ninja_file_to_build_library(path,
+             cuda_flags = _nt_quote_args(cuda_flags)
+             cuda_flags += _nt_quote_args(extra_cuda_cflags)
+         else:
++            if 'CC' in os.environ:
++                cuda_flags += ['-ccbin', os.environ['CC']]
+             cuda_flags += ['--compiler-options', "'-fPIC'"]
+             cuda_flags += extra_cuda_cflags
+             if not any(flag.startswith('-std=') for flag in cuda_flags):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
     - 03-eigen-quiet-build-warning-for-missing-return.patch
     - PR37865-Fix-compile-errors-related-to-disabling-xnnpack.patch
     - 04-onnx-tensorrt-TRT7.patch
+    - 05-cpp-extension.patch
     - PR-41180-Do-not-add-NCCL-dependency-to-gloo.patch
 
 requirements:


### PR DESCRIPTION
This patch addresses two issues with PyTorch's CPP Extension functionality.

1. When building C++ extensions with `nvcc`, `nvcc` will only use the system's version of `gcc`. It should instead use whichever compiler is declared in the `${CC}` variable.

2. On ppc64le, there is a failure when setting `-std=c++14`. Instead, it should be set to `-std=gnu++14` (unless `nvcc` is being used).

These fixes were originally found by @cdeepali .