### PR TITLE
patch to set cmake_minimum_required

### DIFF
--- a/recipe/0100-set-cmake_minimum_required-to-3.14.patch
+++ b/recipe/0100-set-cmake_minimum_required-to-3.14.patch
@@ -1,0 +1,58 @@
+From 0d9314d45cbf1b49c9a9ef5e255b35c748d0c1a7 Mon Sep 17 00:00:00 2001
+From: Deepali Chourasia <deepch23@in.ibm.com>
+Date: Thu, 24 Dec 2020 11:44:05 +0000
+Subject: [PATCH] set cmake_minimum_required to 3.14
+
+---
+ CMakeLists.txt               | 2 +-
+ tools/setup_helpers/cmake.py | 6 +++---
+ torch/CMakeLists.txt         | 2 +-
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0d1225ab45..266593b858 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+ #cmake_policy(SET CMP0022 NEW)
+ #cmake_policy(SET CMP0023 NEW)
+ 
+diff --git a/tools/setup_helpers/cmake.py b/tools/setup_helpers/cmake.py
+index 83253cc3a5..9e5265f300 100644
+--- a/tools/setup_helpers/cmake.py
++++ b/tools/setup_helpers/cmake.py
+@@ -116,13 +116,13 @@ class CMake:
+             return cmake_command
+         cmake3 = which('cmake3')
+         cmake = which('cmake')
+-        if cmake3 is not None and CMake._get_version(cmake3) >= LooseVersion("3.5.0"):
++        if cmake3 is not None and CMake._get_version(cmake3) >= LooseVersion("3.14.0"):
+             cmake_command = 'cmake3'
+             return cmake_command
+-        elif cmake is not None and CMake._get_version(cmake) >= LooseVersion("3.5.0"):
++        elif cmake is not None and CMake._get_version(cmake) >= LooseVersion("3.14.0"):
+             return cmake_command
+         else:
+-            raise RuntimeError('no cmake or cmake3 with version >= 3.5.0 found')
++            raise RuntimeError('no cmake or cmake3 with version >= 3.14.0 found')
+ 
+     @staticmethod
+     def _get_version(cmd):
+diff --git a/torch/CMakeLists.txt b/torch/CMakeLists.txt
+index e5b6e36251..57b09a17c6 100644
+--- a/torch/CMakeLists.txt
++++ b/torch/CMakeLists.txt
+@@ -2,7 +2,7 @@
+ # Now it only builds the Torch python bindings.
+ 
+ if(NOT CAFFE2_CMAKE_BUILDING_WITH_MAIN_REPO)
+-  cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
++  cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+   project(torch CXX C)
+   find_package(torch REQUIRED)
+   option(USE_CUDA "Use CUDA" ON)
+-- 
+2.18.4
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
   git_rev: v{{ version }}
   patches:
     # 01xx - patch is specific to open-ce and will always be carried forward and not upstreamed
+    - 0100-set-cmake_minimum_required-to-3.14.patch
     - 0101-shared-linker.patch
     - 0102-pytorch-tensorrt-Fix-for-GLIBC_2.14.patch # [x86_64 and py<38]
     - 0103-eigen-quiet-build-warning-for-missing-return.patch
@@ -85,7 +86,7 @@ requirements:
     - tensorboard {{ tensorboard }}
 
 build:
-  number: 5
+  number: 6
 {% if build_type == 'cpu' %}
   string: {{ build_type }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
 {% else %}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

@npanpaliya observed PyTorch build fail on a system where `cmake` was pre-installed. PyTorch build picked up system cmake and and the build failed with the following error:

```
Generated: /mnt/pai/home/npanpa23/anaconda3/conda-bld/pytorch-base_1608801657213/work/build/third_party/onnx/onnx/onnx_onnx_torch-ml.proto
Generated: /mnt/pai/home/npanpa23/anaconda3/conda-bld/pytorch-base_1608801657213/work/build/third_party/onnx/onnx/onnx-operators_onnx_torch-ml.proto
CMake Error at third_party/onnx-tensorrt/CMakeLists.txt:21 (cmake_minimum_required):
  CMake 3.13 or higher is required.  You are running version 3.11.4
```

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
