### PR TITLE
fix test_constants_with_final

### DIFF
--- a/recipe/0305-fix-test_constants_with_final.patch
+++ b/recipe/0305-fix-test_constants_with_final.patch
@@ -1,0 +1,34 @@
+diff --git a/test/jit/test_recursive_script.py b/test/jit/test_recursive_script.py
+index 82347b8ca9..58248e9352 100644
+--- a/test/jit/test_recursive_script.py
++++ b/test/jit/test_recursive_script.py
+@@ -2,7 +2,10 @@ import unittest
+ import os
+ import sys
+ import typing
+-import typing_extensions
++if sys.version_info[:2] > (3, 7):
++    from typing import Final
++else:
++    from typing_extensions import Final
+ from typing import List, Dict, Optional, Tuple
+ 
+ import torch
+@@ -174,7 +177,7 @@ class TestRecursiveScript(JitTestCase):
+         self.checkModule(M1(), (torch.randn(2, 2),))
+ 
+         class M2(torch.nn.Module):
+-            x : typing_extensions.Final[int]
++            x : Final[int]
+ 
+             def __init__(self):
+                 super().__init__()
+@@ -187,7 +190,7 @@ class TestRecursiveScript(JitTestCase):
+ 
+         if sys.version_info[:2] >= (3, 8):
+             class M3(torch.nn.Module):
+-                x : typing.Final[int]
++                x : Final[int]
+ 
+                 def __init__(self):
+                     super().__init__()

--- a/tests/open-ce-tests.yaml
+++ b/tests/open-ce-tests.yaml
@@ -5,6 +5,7 @@ tests:
         git clone -b v$(python -c "import torch; print(torch.__version__)") https://github.com/pytorch/pytorch
         cd pytorch
         git apply ${FEEDSTOCK_DIR}/recipe/0304-PR47800-skip-tests-without-fbgemm-support.patch
+        git apply ${FEEDSTOCK_DIR}/recipe/0305-fix-test_constants_with_final.patch
         rm -rf torch
         conda install -y pytest mock hypothesis psutil
 {% if python=='3.6' %}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

The tests - test_jit_fuser_te is using typing_extension for py38, so am seeing following test failure with py38:
```
  File "test_jit_fuser_te.py", line 28, in <module>
    from test_jit import backward_graph, all_backward_graphs, get_lstm_inputs, get_milstm_inputs, \
  File "/home/builder/pytorch/test/test_jit.py", line 8, in <module>
    from jit.test_recursive_script import TestRecursiveScript  # noqa: F401
  File "/home/builder/pytorch/test/jit/test_recursive_script.py", line 5, in <module>
    import typing_extensions
ModuleNotFoundError: No module named 'typing_extensions'
Traceback (most recent call last):
  File "test/run_test.py", line 745, in <module>
    main()
  File "test/run_test.py", line 728, in main
    raise RuntimeError(err_message)
RuntimeError: test_jit_fuser_te failed!
```


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
