### PR TITLE
set USE_TBB and package tbb headers

### DIFF
--- a/recipe/0306-package-tbb-headers.patch
+++ b/recipe/0306-package-tbb-headers.patch
@@ -1,0 +1,59 @@
+From 3b6d4a22e44c21e9da51c74e33a7c67fa12f9330 Mon Sep 17 00:00:00 2001
+From: Deepali Chourasia <deepch23@in.ibm.com>
+Date: Thu, 15 Jul 2021 14:02:59 +0000
+Subject: [PATCH] package tbb headers
+
+---
+ cmake/Dependencies.cmake | 6 ++++++
+ setup.py                 | 2 +-
+ torch/CMakeLists.txt     | 4 ++++
+ 3 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/cmake/Dependencies.cmake b/cmake/Dependencies.cmake
+index d1e4bdaed6..901ee42cd4 100644
+--- a/cmake/Dependencies.cmake
++++ b/cmake/Dependencies.cmake
+@@ -97,6 +97,12 @@ if(USE_TBB)
+   set_property(TARGET tbb tbb_def_files PROPERTY FOLDER "dependencies")
+ 
+   set(CMAKE_CXX_FLAGS ${OLD_CMAKE_CXX_FLAGS})
++
++  set(tbb_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/../third_party/tbb/include)
++  install(DIRECTORY ${tbb_INCLUDE_DIRS}
++            DESTINATION ${CMAKE_INSTALL_PREFIX}
++            FILES_MATCHING PATTERN "*.h")
++
+ endif()
+ 
+ # ---[ protobuf
+diff --git a/setup.py b/setup.py
+index 2db381644c..a34de2501f 100644
+--- a/setup.py
++++ b/setup.py
+@@ -902,7 +902,7 @@ if __name__ == '__main__':
+                 'share/cmake/Gloo/*.cmake',
+                 'share/cmake/Tensorpipe/*.cmake',
+                 'share/cmake/Torch/*.cmake',
+-            ],
++            ] + (['include/tbb/*.h','include/tbb/combat/*.h','include/tbb/internal/*.h','include/tbb/machine/*.h'] if os.environ.get('USE_TBB') == '1' else []),
+             'caffe2': [
+                 'python/serialized_test/data/operator_test/*.zip',
+             ],
+diff --git a/torch/CMakeLists.txt b/torch/CMakeLists.txt
+index e5b6e36251..cd9fba01f4 100644
+--- a/torch/CMakeLists.txt
++++ b/torch/CMakeLists.txt
+@@ -72,6 +72,10 @@ set(TORCH_PYTHON_INCLUDE_DIRECTORIES
+     ${TORCH_ROOT}/third_party/onnx
+     ${pybind11_INCLUDE_DIRS}
+ 
++if(USE_TBB)
++    ${tbb_INCLUDE_DIRS}
++endif()
++
+     ${TORCH_SRC_DIR}/csrc
+     ${TORCH_SRC_DIR}/csrc/api/include
+     ${TORCH_SRC_DIR}/lib
+-- 
+2.23.0
+

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -50,7 +50,8 @@ export USE_PYTORCH_QNNPACK=0
 export TH_BINARY_BUILD=1
 export USE_LMDB=1
 export USE_LEVELDB=1
-export USE_OPENMP=1
+export USE_OPENMP=0
+export USE_TBB=1
 export USE_NINJA=0
 export USE_MPI=0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ source:
     - 0301-PR37865-Fix-compile-errors-related-to-disabling-xnnpack.patch
     - 0302-cpp-extension.patch
     - 0303-PR47677-remove-references-to-typing-module.patch
+    - 0306-package-tbb-headers.patch
 
 requirements:
   build:
@@ -94,7 +95,7 @@ requirements:
     - tensorboard {{ tensorboard }}
 
 build:
-  number: 18
+  number: 19
 {% if build_type == 'cpu' %}
   string: h{{ PKG_HASH }}_{{ build_type }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
 {% else %}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

As of now there is a restriction to use `OMP_NUM_THREADS=1` with PyTorch to avoid following warnings and probable hangs. `OpenBLAS Warning : Detect OpenMP Loop and this application may hang. Please rebuild the library with USE_OPENMP=1 option.` 
This however, makes trainings too slow. 

This PR enables usage of TBB for Intra-op Parallelism. https://pytorch.org/docs/stable/notes/cpu_threading_torchscript_inference.html  

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
