### PR TITLE
[main] use TBB for CPU and OpenMP for CUDA

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -50,8 +50,6 @@ export USE_PYTORCH_QNNPACK=0
 export TH_BINARY_BUILD=1
 export USE_LMDB=1
 export USE_LEVELDB=1
-export USE_OPENMP=0
-export USE_TBB=1
 export USE_NINJA=0
 export USE_MPI=0
 
@@ -91,12 +89,16 @@ then
   export USE_CUDA=0
   export USE_CUDNN=0
   export USE_TENSORRT=0
+  export USE_OPENMP=0
+  export USE_TBB=1
 
 elif [[ $build_type == "cuda" ]]
 then
   # Enable GPU-related libraries
   export USE_CUDA=1
   export USE_CUDNN=1
+  export USE_OPENMP=1
+  export USE_TBB=0
   
   export TORCH_CUDA_ARCH_LIST="3.7;6.0;7.0;7.5"
   if [[ $CUDA_VERSION == '11' ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - 0301-PR37865-Fix-compile-errors-related-to-disabling-xnnpack.patch
     - 0302-cpp-extension.patch
     - 0303-PR52091-Update-vec_mergee-operand-specifiers.patch
-    - 0307-package-tbb-headers.patch
+    - 0307-package-tbb-headers.patch                 #[build_type=='cpu']
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -93,7 +93,7 @@ requirements:
     - tensorboard {{ tensorboard }}
 
 build:
-  number: 5
+  number: 6
 {% if build_type == 'cpu' %}
   string: h{{ PKG_HASH }}_{{ build_type }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
 {% else %}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

The following warning is seen with TBB enabled PyTorch build on GPU based trainings:
```
Running epoch 1 ... It might take several minutes for each epoch to run.
TBB Warning: The number of workers is currently limited to 0. The request for 15 workers is ignored. Further requests for more workers will be silently ignored until the limit changes.
Train - batches : 1, average loss: 2.4288, accuracy: 3/32 (9%)
Train - batches : 2, average loss: 2.4631, accuracy: 7/64 (11%)
```
And looks like TBB enabled GPU PyTorch is slower. So disabling TBB for GPU builds. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
