### PR TITLE
add fix for pip check for py37

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,6 +61,8 @@ requirements:
     - pillow
     - typing_extensions {{ typing_extensions }}
     - click {{ click }}
+    # https://github.com/AnacondaRecipes/click-feedstock/issues/4
+    - importlib-metadata                     # [py<38]
     - networkx {{ networkx }}
     - scipy {{ scipy }}
     - numactl {{ numactl }}
@@ -80,7 +82,7 @@ requirements:
     - tensorboard {{ tensorboard }}
 
 build:
-  number: 1
+  number: 2
 {% if build_type == 'cpu' %}
   string: h{{ PKG_HASH }}_{{ build_type }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
 {% else %}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Fixes the error :
```
click 8.0.3 requires importlib-metadata, which is not installed.
TESTS FAILED: pytorch-base-1.10.2-h1234567_cpu_py37_pb3.14_1.conda
```


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
