### PR TITLE
fix build by not compiling half-test.cpp

### DIFF
--- a/recipe/0109-skip-half-test.patch
+++ b/recipe/0109-skip-half-test.patch
@@ -1,0 +1,12 @@
+diff --git a/aten/src/ATen/test/CMakeLists.txt b/aten/src/ATen/test/CMakeLists.txt
+index ee6a9ee30f..fcdb9b72a1 100644
+--- a/aten/src/ATen/test/CMakeLists.txt
++++ b/aten/src/ATen/test/CMakeLists.txt
+@@ -12,7 +12,6 @@ list(APPEND ATen_CPU_TEST_SRCS
+   ${CMAKE_CURRENT_SOURCE_DIR}/Dimname_test.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/Dict_test.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/NamedTensor_test.cpp
+-  ${CMAKE_CURRENT_SOURCE_DIR}/half_test.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/broadcast_test.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/wrapdim_test.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/dlconvertor_test.cpp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,8 @@ source:
     - 0106-disable-SHM-and-CMA-for-tensorpipe.patch
     - 0107-fix-clock-gettime-undefind-error-for-sleef.patch
     - 0108-change-mcpu-and-mtune.patch                #[ppc_arch == "p10"]
+    #temporarily skip compiling half-test.cpp
+    - 0109-skip-half-test.patch                       #[ppc64le and ppc_arch == "p9"]
 
     # 03xx - patch temporary to fix a problem that when fixed upstream can be removed
     - 0302-cpp-extension.patch
@@ -84,7 +86,7 @@ requirements:
     - tensorboard {{ tensorboard }}
 
 build:
-  number: 5
+  number: 6
 {% if build_type == 'cpu' %}
   string: h{{ PKG_HASH }}_{{ build_type }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
 {% else %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - 0106-disable-SHM-and-CMA-for-tensorpipe.patch
     - 0107-fix-clock-gettime-undefind-error-for-sleef.patch
     - 0108-change-mcpu-and-mtune.patch                #[ppc_arch == "p10"]
-    #temporarily skip compiling half-test.cpp
+    #skip compiling half-test.cpp
     - 0109-skip-half-test.patch                       #[ppc64le and ppc_arch == "p9"]
 
     # 03xx - patch temporary to fix a problem that when fixed upstream can be removed


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

skipping to compile half_test.cpp as it leads to error in p9 build. I think this is harmless change because it is used by one caffe2 test.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
