### PR TITLE
fix build by adding pin for snappy

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - {{ compiler('fortran') }}          #[ppc_arch != "p10"]
     - git >={{ git }}
     - patch
+    - snappy 1.1.8
 
   host:
     - make
@@ -45,6 +46,7 @@ requirements:
     - lmdb {{ lmdb }}
     - leveldb {{ leveldb }}
     - typing_extensions {{ typing_extensions }}
+    - snappy 1.1.8
 {% if build_type == 'cuda' %}
     - cudnn {{ cudnn }}
     - nccl {{ nccl }}
@@ -83,7 +85,7 @@ requirements:
     - tensorboard {{ tensorboard }}
 
 build:
-  number: 3
+  number: 4
 {% if build_type == 'cpu' %}
   string: h{{ PKG_HASH }}_{{ build_type }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
 {% else %}


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Newer version of `snappy `is causing errors during build, so pinning to older version. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
