### PR TITLE
[1.11.7] Fix CVE-2025-2953 and CVE-2025-3730 by backporting pytorch to v2.1.2

### DIFF
--- a/pytorch-2.1.2/recipe/0314-fix-CVE-2025-2953.patch
+++ b/pytorch-2.1.2/recipe/0314-fix-CVE-2025-2953.patch
@@ -1,0 +1,41 @@
+From 923f14932fb79728287355806f854dd65258070b Mon Sep 17 00:00:00 2001
+From: "Archana.Shinde1" <archana.shinde1@ibm.com>
+Date: Fri, 11 Jul 2025 06:57:31 +0000
+Subject: [PATCH] fix CVE-2025-2953
+
+---
+ aten/src/ATen/native/mkldnn/Utils.cpp | 1 +
+ test/test_mkldnn.py                   | 6 ++++++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/aten/src/ATen/native/mkldnn/Utils.cpp b/aten/src/ATen/native/mkldnn/Utils.cpp
+index bebc54046f1..313af8a37f2 100644
+--- a/aten/src/ATen/native/mkldnn/Utils.cpp
++++ b/aten/src/ATen/native/mkldnn/Utils.cpp
+@@ -19,6 +19,7 @@ std::vector<int64_t> pool_output_sizes(
+   output_size[1] = input_size[1];
+ 
+   for (const auto i : c10::irange(2, input_size.size())) {
++    TORCH_CHECK_VALUE(stride[i -2] > 0, "Strides must be positive!");
+     output_size[i] = pooling_output_shape_pad_lr<int64_t>(
+       input_size[i],
+       kernel_size[i - 2],
+diff --git a/test/test_mkldnn.py b/test/test_mkldnn.py
+index bad719254da..65845b3f9ed 100644
+--- a/test/test_mkldnn.py
++++ b/test/test_mkldnn.py
+@@ -1488,5 +1488,11 @@ class TestMkldnn(TestCase):
+             y2 = torch.bmm(a2, b)
+             self.assertEqual(y1, y2)
+ 
++    def test_mkldnn_error_on_zero_stride(self, device):
++        # Regression test for https://github.com/pytorch/pytorch/issues/149274
++        x = torch.rand(1, 2, 3, 3).to_mkldnn()
++        with self.assertRaises(ValueError):
++            torch.mkldnn_max_pool2d(x, kernel_size=3, stride=0)
++
+ if __name__ == '__main__':
+     run_tests()
+-- 
+2.40.1
+

--- a/pytorch-2.1.2/recipe/0315-fix-CVE-2025-3730.patch
+++ b/pytorch-2.1.2/recipe/0315-fix-CVE-2025-3730.patch
@@ -1,0 +1,58 @@
+From 655efdd101e8388b9986c10c3624951428455589 Mon Sep 17 00:00:00 2001
+From: "Archana.Shinde1" <archana.shinde1@ibm.com>
+Date: Fri, 11 Jul 2025 06:44:53 +0000
+Subject: [PATCH] fix CVE-2025-3730
+
+---
+ aten/src/ATen/native/LossCTC.cpp     | 1 +
+ aten/src/ATen/native/cuda/LossCTC.cu | 1 +
+ test/test_nn.py                      | 9 +++++++++
+ 3 files changed, 11 insertions(+)
+
+diff --git a/aten/src/ATen/native/LossCTC.cpp b/aten/src/ATen/native/LossCTC.cpp
+index 0d497e6b095..3fb39f2bab8 100644
+--- a/aten/src/ATen/native/LossCTC.cpp
++++ b/aten/src/ATen/native/LossCTC.cpp
+@@ -59,6 +59,7 @@ static inline int64_t get_target_prime(target_t* target, int64_t offset, int64_t
+ // the alphas from the user by only returning the loss.
+ template<typename scalar_t, ScalarType target_scalar_type>
+ std::tuple<Tensor, Tensor> ctc_loss_cpu_template(const Tensor& log_probs, const Tensor& targets, IntArrayRef input_lengths, IntArrayRef target_lengths, int64_t BLANK) {
++  TORCH_CHECK(log_probs.numel() > 0, "log_probs tensor must not be empty");
+   // log_probs: input_len x batch_size x num_labels
+   // targets [int64]: batch_size x target_length OR sum(target_lengths)
+   constexpr scalar_t neginf = -std::numeric_limits<scalar_t>::infinity();
+diff --git a/aten/src/ATen/native/cuda/LossCTC.cu b/aten/src/ATen/native/cuda/LossCTC.cu
+index 5fb86d16e95..4bb90fc8449 100644
+--- a/aten/src/ATen/native/cuda/LossCTC.cu
++++ b/aten/src/ATen/native/cuda/LossCTC.cu
+@@ -211,6 +211,7 @@ ctc_loss_log_alpha_gpu_kernel(scalar_t* __restrict__ log_alpha_data,
+ // backward. The dispatch function will only return the loss.
+ template<typename scalar_t, ScalarType target_scalar_type>
+ std::tuple<Tensor, Tensor> ctc_loss_gpu_template(const Tensor& log_probs, const Tensor& targets, IntArrayRef input_lengths, IntArrayRef target_lengths, int64_t BLANK) {
++  TORCH_CHECK(log_probs.numel() > 0, "log_probs tensor must not be empty");
+   // log_probs: input_len x batch_size x num_labels
+   // targets [int64]: batch_size x target_length OR sum(target_lengths)
+   CheckedFrom c = "ctc_loss_gpu";
+diff --git a/test/test_nn.py b/test/test_nn.py
+index 40d17c47161..c01a1a75dd7 100644
+--- a/test/test_nn.py
++++ b/test/test_nn.py
+@@ -11261,6 +11261,15 @@ class TestNNDeviceType(NNTestCase):
+         grad_cudnn, = torch.autograd.grad(loss_cudnn, log_probs, grad_out)
+         self.assertEqual(grad_cudnn, grad_native, atol=1e-4, rtol=0)
+ 
++    @expectedFailureMPS
++    def test_ctc_loss_error(self, device):
++        log_probs = torch.rand(0, 0, 4, device=device)
++        targets = torch.tensor([], device=device, dtype=torch.long)
++        input_lengths = torch.tensor([], device=device, dtype=torch.long)
++        target_lengths = torch.tensor([], device=device, dtype=torch.long)
++        with self.assertRaisesRegex(RuntimeError, "log_probs tensor must not be empty"):
++            F.ctc_loss(log_probs, targets, input_lengths, target_lengths, reduction='none')
++
+     @dtypesIfCUDA(torch.half, torch.float, torch.double)
+     @dtypes(torch.float)
+     @tf32_on_and_off(0.005)
+-- 
+2.40.1
+

--- a/pytorch-2.1.2/recipe/meta.yaml
+++ b/pytorch-2.1.2/recipe/meta.yaml
@@ -22,6 +22,8 @@ source:
     - 0312-Disabled-Wno-error-flag-for-p10.patch #[ppc_arch == "p10"]
     - 0001-Fix-logic-to-find-sbgemm-in-BLAS-library.patch  #[ppc_arch == "p10"]
     - 0313-Fix-for-CVE-2024-31583-and-CVE-2024-31580.patch
+    - 0314-fix-CVE-2025-2953.patch
+    - 0315-fix-CVE-2025-3730.patch
 
 requirements:
   build:


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
